### PR TITLE
Mention --fix bug in comment

### DIFF
--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -184,7 +184,9 @@ function validate(context: TSESLint.RuleContext<MessageIds, [Options]>, options:
         let applied = false;
         return {
           range: [start, start],
-          // Trick: Function `fix` is ALWAYS run, and result is collected. However RuleFix objects are only read if `--fix` is passed
+          // Bug: previously, ESLint would only read RuleFix objects if `--fix` is passed. Now it seems to no matter what.
+          // TODO: See if we can only update snapshots if `--fix` is passed?
+          // See: https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/issues/14
           get text() {
             if (!applied) {
               // Make sure we update snapshot only on first read of this object


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing issue: references #14
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/labels/status%3A%20accepting%20prs)

## Overview

I don't know how to fix the bug or if it's possible to now with the options passed to ESLint rules. This just mentions it in code.