### PR TITLE
Set space to 2 for pretty snapshot

### DIFF
--- a/src/utils/snapshot.ts
+++ b/src/utils/snapshot.ts
@@ -16,7 +16,7 @@ export const updateTypeSnapshot = (filename: string, snapshotName: string, actua
 
   const json = readJsonSync(snapshotPath, { throws: false }) || {};
   json[snapshotName] = actualType;
-  writeJsonSync(snapshotPath, json);
+  writeJsonSync(snapshotPath, json, { spaces: 2 });
 };
 
 function getSnapshotPath(filename: string) {


### PR DESCRIPTION

## PR Checklist

- [ ] Addresses an existing issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/labels/status%3A%20accepting%20prs)

## Overview

Having unformatted snap makes it really hard to review changes.

For example, if you refactor your code and change just 1 type, in git diff, it looks like the entire file is changed. It's really hard to read and understand if the diff is valid or not.

Before:

<img width="839" alt="Screen Shot 2021-01-28 at 23 22 35" src="https://user-images.githubusercontent.com/16444991/106194345-bd72d780-61bf-11eb-92a5-4f328eb51d92.png">


After:

<img width="1182" alt="Screen Shot 2021-01-28 at 23 20 36" src="https://user-images.githubusercontent.com/16444991/106194354-c2378b80-61bf-11eb-9d41-77a97d354b1f.png">


