### PR TITLE
Add twoslash support

### DIFF
--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -407,11 +407,29 @@ function parseAssertions(sourceFile: ts.SourceFile): Assertions {
 
       case '^?': {
         // TODO: match error checking from ExpectType
-        const expected = payload;
+        let expected = payload;
         if (expected) {
           // // ^?
           // 01234 <-- so add three... but also subtract 1?
-          const position = commentCol - lineStarts[line - 1] + lineStarts[line - 2] + whitespace.length + 3 - 1;
+          const position = commentCol - lineStarts[line - 1] + lineStarts[line - 2] + whitespace.length + 2;
+
+          // Peak ahead to the next lines to see if the expected type continues
+          const twoSlashPrefix = text.slice(lineStarts[line - 1], commentCol + 2 + whitespace.length);
+          for (let nextLine = line; nextLine < lineStarts.length; nextLine++) {
+            const lineText = text.slice(
+              lineStarts[nextLine],
+              nextLine + 1 < lineStarts.length ? lineStarts[nextLine + 1] : undefined,
+            );
+            if (lineText.startsWith(twoSlashPrefix)) {
+              if (nextLine === line) {
+                expected += '\n';
+              }
+              expected += lineText.slice(twoSlashPrefix.length);
+            } else {
+              break;
+            }
+          }
+
           twoSlashAssertions.push({ position, expected });
         }
         break;

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -221,7 +221,6 @@ function validate(context: TSESLint.RuleContext<MessageIds, [Options]>, options:
       context.report({
         ...templateDescriptor,
         messageId: 'TypesDoNotMatch',
-        /*
         ...(assertion.assertionType === 'twoslash'
           ? {
               fix: (): TSESLint.RuleFix => {
@@ -232,7 +231,6 @@ function validate(context: TSESLint.RuleContext<MessageIds, [Options]>, options:
               },
             }
           : {}),
-        */
       });
     }
   }

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -398,6 +398,12 @@ function parseAssertions(sourceFile: ts.SourceFile): Assertions {
         // TODO: match error checking from ExpectType
         let expected = payload;
         if (expected) {
+          if (line === 1) {
+            // This will become an attachment error later.
+            twoSlashAssertions.push({ position: -1, expected, expectedRange: [-1, -1], expectedPrefix: '' });
+            break;
+          }
+
           // // ^?
           // 01234 <-- so add three... but also subtract 1?
           const position = commentCol - lineStarts[line - 1] + lineStarts[line - 2] + whitespace.length + 2;
@@ -568,6 +574,11 @@ function getExpectTypeFailures(
   if (twoSlashAssertions.length) {
     for (const assertion of twoSlashAssertions) {
       const { position, expected } = assertion;
+      if (position === -1) {
+        // special case for a twoslash assertion on line 1.
+        twoSlashFailureLines.push(0);
+        continue;
+      }
       const node = getNodeAtPosition(sourceFile, position);
       if (!node) {
         twoSlashFailureLines.push(sourceFile.getLineAndCharacterOfPosition(position).line);

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -6,35 +6,6 @@ import { getParserServices } from '../utils/getParserServices';
 import { loc } from '../utils/loc';
 import { getTypeSnapshot, updateTypeSnapshot } from '../utils/snapshot';
 
-function getLanguageServiceHost(fileName: string, source: string): ts.LanguageServiceHost {
-  return {
-    getCompilationSettings() {
-      return {
-        noResolve: true,
-        target: ts.ScriptTarget.ES5,
-      };
-    },
-    getCurrentDirectory() {
-      return '';
-    },
-    getDefaultLibFileName: function () {
-      return 'lib.d.ts';
-    },
-    getScriptFileNames: function () {
-      return [fileName];
-    },
-    getScriptSnapshot: function (name) {
-      return ts.ScriptSnapshot.fromString(name === fileName ? source : '');
-    },
-    getScriptVersion: function () {
-      return '1';
-    },
-    log(s) {
-      console.log('LSSH log', s);
-    },
-  };
-}
-
 const messages = {
   TypeScriptCompileError: 'TypeScript compile error: {{ message }}',
   FileIsNotIncludedInTsconfig: 'Expected to find a file "{{ fileName }}" present.',
@@ -520,6 +491,20 @@ function matchReadonlyArray(actual: string, expected: string) {
   }
 
   return true;
+}
+
+function getLanguageServiceHost(fileName: string, source: string): ts.LanguageServiceHost {
+  return {
+    getCompilationSettings: () => ({
+      noResolve: true,
+      target: ts.ScriptTarget.ES5,
+    }),
+    getCurrentDirectory: () => '',
+    getDefaultLibFileName: () => 'lib.d.ts',
+    getScriptFileNames: () => [fileName],
+    getScriptSnapshot: (name) => ts.ScriptSnapshot.fromString(name === fileName ? source : ''),
+    getScriptVersion: () => '1',
+  };
 }
 
 function getExpectTypeFailures(

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -405,8 +405,8 @@ function parseAssertions(sourceFile: ts.SourceFile): Assertions {
           // Peak ahead to the next lines to see if the expected type continues
           const expectedPrefix = text.slice(lineStarts[line - 1], commentCol + 2 + whitespace.length);
           for (let nextLine = line; nextLine < lineStarts.length; nextLine++) {
-            const thisLineEnd = nextLine + 1 < lineStarts.length ? lineStarts[nextLine + 1] - 1 : text.length - 1;
-            const lineText = text.slice(lineStarts[nextLine], thisLineEnd);
+            const thisLineEnd = nextLine + 1 < lineStarts.length ? lineStarts[nextLine + 1] - 1 : text.length;
+            const lineText = text.slice(lineStarts[nextLine], thisLineEnd + 1);
             if (lineText.startsWith(expectedPrefix)) {
               if (nextLine === line) {
                 expected += '\n';

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -397,7 +397,7 @@ function parseAssertions(sourceFile: ts.SourceFile): Assertions {
           // 01234 <-- so add three... but also subtract 1?
           const position = commentCol - lineStarts[line - 1] + lineStarts[line - 2] + whitespace.length + 2;
 
-          const expectedRange: [number, number] = [commentCol + whitespace.length, lineStarts[line] - 1];
+          const expectedRange: [number, number] = [commentCol + whitespace.length + 5, lineStarts[line] - 1];
           // Peak ahead to the next lines to see if the expected type continues
           const expectedPrefix = text.slice(lineStarts[line - 1], commentCol + 2 + whitespace.length);
           for (let nextLine = line; nextLine < lineStarts.length; nextLine++) {

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -371,9 +371,6 @@ function parseAssertions(sourceFile: ts.SourceFile): Assertions {
         if (expected) {
           // // ^?
           // 01234 <-- so add three
-          console.log(commentCol);
-          console.log(line);
-          console.log(lineStarts);
           const column = commentCol - lineStarts[line - 1] + whitespace.length + 3 - 1;
           typeAssertions.set(line - 2, { assertionType: 'manual', expected, column });
         }
@@ -382,7 +379,6 @@ function parseAssertions(sourceFile: ts.SourceFile): Assertions {
     }
   }
 
-  console.log(typeAssertions);
   return { errorLines, typeAssertions, duplicates, syntaxErrors };
 
   function getLine(pos: number): number {

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -576,11 +576,7 @@ function getExpectTypeFailures(
 
       const qi = languageService.getQuickInfoAtPosition(sourceFile.fileName, node.getStart());
       if (!qi || !qi.displayParts) {
-        unmetExpectations.push({
-          assertion: { assertionType: 'twoslash', ...assertion },
-          node,
-          actual: '(Unable to get quickinfo)',
-        });
+        twoSlashFailureLines.push(sourceFile.getLineAndCharacterOfPosition(position).line);
         continue;
       }
       const actual = qi.displayParts.map((dp) => dp.text).join('');

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -402,7 +402,10 @@ function parseAssertions(sourceFile: ts.SourceFile): Assertions {
           // 01234 <-- so add three... but also subtract 1?
           const position = commentCol - lineStarts[line - 1] + lineStarts[line - 2] + whitespace.length + 2;
 
-          const expectedRange: [number, number] = [commentCol + whitespace.length + 5, lineStarts[line] - 1];
+          const expectedRange: [number, number] = [
+            commentCol + whitespace.length + 5,
+            line < lineStarts.length ? lineStarts[line] - 1 : text.length,
+          ];
           // Peak ahead to the next lines to see if the expected type continues
           const expectedPrefix = text.slice(lineStarts[line - 1], commentCol + 2 + whitespace.length) + '   ';
           for (let nextLine = line; nextLine < lineStarts.length; nextLine++) {

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -549,17 +549,16 @@ function getExpectTypeFailures(
       if (column !== undefined) {
         const qi = ls.getQuickInfoAtPosition(sourceFile.fileName, node.getStart());
         if (qi) {
-          console.log(node.getText());
-          console.log(qi);
           if (qi.displayParts) {
-            const before = actual;
             actual = qi.displayParts.map((dp) => dp.text).join('');
-            console.log(before, actual);
           }
         }
       }
 
-      if (!expected || (actual !== expected && !matchReadonlyArray(actual, expected))) {
+      if (
+        !expected ||
+        (actual !== expected && !matchReadonlyArray(actual, expected) && !matchModuloWhitespace(actual, expected))
+      ) {
         unmetExpectations.push({ assertion, node, actual });
       }
 
@@ -569,6 +568,14 @@ function getExpectTypeFailures(
     ts.forEachChild(node, iterate);
   });
   return { unmetExpectations, unusedAssertions: typeAssertions.keys() };
+}
+
+function matchModuloWhitespace(actual: string, expected: string): boolean {
+  // TODO: it's much easier to normalize actual based on the displayParts
+  const normActual = actual.replace(/[\n ]+/g, ' ');
+  // console.log(actual, normActual);
+  const normExpected = expected.replace(/[\n ]+/g, ' ');
+  return normActual === normExpected;
 }
 
 function getNodeForExpectType(node: ts.Node): ts.Node {

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -379,7 +379,6 @@ function parseAssertions(sourceFile: ts.SourceFile): Assertions {
     }
   }
 
-  console.log(typeAssertions);
   return { errorLines, typeAssertions, duplicates, syntaxErrors };
 
   function getLine(pos: number): number {
@@ -481,32 +480,22 @@ function getExpectTypeFailures(
 
       let nodeToCheck = node;
       if (column !== undefined) {
-        let outcome: 'match' | 'deeper' | 'bail' = 'deeper';
+        let isMatch = false;
         const startCol = sourceFile.getLineAndCharacterOfPosition(node.getStart()).character;
         const endCol = sourceFile.getLineAndCharacterOfPosition(node.getEnd()).character;
-        console.log(column, startCol, endCol, node.getText());
         if (startCol <= column && endCol >= column) {
           if (node.getChildCount() === 0) {
-            console.log('match', node.getText());
-            outcome = 'match';
+            isMatch = true;
           } else {
-            outcome = 'deeper';
             // matching span, but we can go deeper
-            console.log('go deeper', node.getText());
           }
         } else if (startCol > column || endCol < column) {
-          console.log('bail', node.getText());
-          outcome = 'bail';
-        } else {
-          console.log('fall through to recursion', node.getText());
+          return; // no possible match
         }
 
-        if (outcome === 'deeper') {
+        if (!isMatch) {
           ts.forEachChild(node, iterate);
           return;
-        } else if (outcome === 'bail') {
-          console.log('no match for', node.getText());
-          return; // no match, keep looking elsewhere
         }
       } else {
         // https://github.com/Microsoft/TypeScript/issues/14077

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -605,9 +605,9 @@ function getNodeAtPosition(sourceFile: ts.SourceFile, position: number): ts.Node
 
 function matchModuloWhitespace(actual: string, expected: string): boolean {
   // TODO: it's much easier to normalize actual based on the displayParts
-  const normActual = actual.replace(/[\n ]+/g, ' ');
+  const normActual = actual.replace(/[\n ]+/g, ' ').trim();
   // console.log(actual, normActual);
-  const normExpected = expected.replace(/[\n ]+/g, ' ');
+  const normExpected = expected.replace(/[\n ]+/g, ' ').trim();
   return normActual === normExpected;
 }
 

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -226,7 +226,10 @@ function validate(context: TSESLint.RuleContext<MessageIds, [Options]>, options:
               fix: (): TSESLint.RuleFix => {
                 return {
                   range: assertion.expectedRange,
-                  text: actual,
+                  text: actual
+                    .split('\n')
+                    .map((line, i) => (i > 0 ? assertion.expectedPrefix + line : line))
+                    .join('\n'),
                 };
               },
             }
@@ -401,7 +404,7 @@ function parseAssertions(sourceFile: ts.SourceFile): Assertions {
 
           const expectedRange: [number, number] = [commentCol + whitespace.length + 5, lineStarts[line] - 1];
           // Peak ahead to the next lines to see if the expected type continues
-          const expectedPrefix = text.slice(lineStarts[line - 1], commentCol + 2 + whitespace.length);
+          const expectedPrefix = text.slice(lineStarts[line - 1], commentCol + 2 + whitespace.length) + '   ';
           for (let nextLine = line; nextLine < lineStarts.length; nextLine++) {
             const thisLineEnd = nextLine + 1 < lineStarts.length ? lineStarts[nextLine + 1] - 1 : text.length;
             const lineText = text.slice(lineStarts[nextLine], thisLineEnd + 1);

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -482,6 +482,7 @@ function getExpectTypeFailures(
     if (assertion !== undefined) {
       const { expected, column } = assertion;
 
+      let nodeToCheck = node;
       if (column !== undefined) {
         if (node.getStart() <= column && node.getEnd() >= column && node.getChildCount() === 0) {
           // we have our node
@@ -495,10 +496,10 @@ function getExpectTypeFailures(
         if (node.kind === ts.SyntaxKind.ExpressionStatement) {
           node = (node as ts.ExpressionStatement).expression;
         }
-        node = getNodeForExpectType(node);
+        nodeToCheck = getNodeForExpectType(node);
       }
 
-      const type = checker.getTypeAtLocation(node);
+      const type = checker.getTypeAtLocation(nodeToCheck);
 
       const actual = type
         ? checker.typeToString(type, /*enclosingDeclaration*/ undefined, ts.TypeFormatFlags.NoTruncation)

--- a/tests/rules/expect-type.test.ts
+++ b/tests/rules/expect-type.test.ts
@@ -58,7 +58,6 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       },
     ],
   },
-  /*
   {
     code: dedent`
       //$ExpectType number
@@ -88,7 +87,6 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       },
     ],
   },
-  */
 ];
 
 describe('$ExpectType', () => {

--- a/tests/rules/expect-type.test.ts
+++ b/tests/rules/expect-type.test.ts
@@ -6,14 +6,6 @@ import { name, rule } from '../../src/rules/expect';
 
 // Valid test cases.
 const valid: ReadonlyArray<ValidTestCase> = [
-  // Twoslash
-  {
-    code: dedent`
-      const t = { a: 17, b: 'on' as const };
-      //    ^? const t: { a: number; b: "on"; }
-    `,
-    optionsSet: [[]],
-  },
   // Complex type
   {
     code: dedent`
@@ -27,15 +19,6 @@ const valid: ReadonlyArray<ValidTestCase> = [
     code: dedent`
       // $ExpectType number
       const t = 6 as number;
-    `,
-    optionsSet: [[]],
-  },
-  // Twoslash type from #4
-  {
-    code: dedent`
-      const square = (x: number) => x * x;
-      const four = square(2);
-      //    ^? const four: number
     `,
     optionsSet: [[]],
   },

--- a/tests/rules/expect-type.test.ts
+++ b/tests/rules/expect-type.test.ts
@@ -6,11 +6,11 @@ import { name, rule } from '../../src/rules/expect';
 
 // Valid test cases.
 const valid: ReadonlyArray<ValidTestCase> = [
-  // Primitive type
+  // Twoslash
   {
     code: dedent`
-      // $ExpectType number
-      const t = 6 as number;
+      const t = { a: 17, b: 'on' as const };
+      //    ^? { a: number; b: "on"; }
     `,
     optionsSet: [[]],
   },
@@ -19,6 +19,14 @@ const valid: ReadonlyArray<ValidTestCase> = [
     code: dedent`
       // $ExpectType { a: number; b: "on"; }
       const t = { a: 17, b: 'on' as const };
+    `,
+    optionsSet: [[]],
+  },
+  // Primitive type
+  {
+    code: dedent`
+      // $ExpectType number
+      const t = 6 as number;
     `,
     optionsSet: [[]],
   },
@@ -50,6 +58,7 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       },
     ],
   },
+  /*
   {
     code: dedent`
       //$ExpectType number
@@ -79,6 +88,7 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       },
     ],
   },
+  */
 ];
 
 describe('$ExpectType', () => {

--- a/tests/rules/expect-type.test.ts
+++ b/tests/rules/expect-type.test.ts
@@ -10,10 +10,9 @@ const valid: ReadonlyArray<ValidTestCase> = [
   {
     code: dedent`
       const t = { a: 17, b: 'on' as const };
-      //    ^? { a: number; b: "on"; }
+      //    ^? const t: { a: number; b: "on"; }
     `,
     optionsSet: [[]],
-    only: true,
   },
   // Complex type
   {
@@ -36,7 +35,7 @@ const valid: ReadonlyArray<ValidTestCase> = [
     code: dedent`
       const square = (x: number) => x * x;
       const four = square(2);
-      //    ^? number
+      //    ^? const four: number
     `,
     optionsSet: [[]],
   },

--- a/tests/rules/expect-type.test.ts
+++ b/tests/rules/expect-type.test.ts
@@ -6,19 +6,19 @@ import { name, rule } from '../../src/rules/expect';
 
 // Valid test cases.
 const valid: ReadonlyArray<ValidTestCase> = [
-  // Complex type
-  {
-    code: dedent`
-      // $ExpectType { a: number; b: "on"; }
-      const t = { a: 17, b: 'on' as const };
-    `,
-    optionsSet: [[]],
-  },
   // Primitive type
   {
     code: dedent`
       // $ExpectType number
       const t = 6 as number;
+    `,
+    optionsSet: [[]],
+  },
+  // Complex type
+  {
+    code: dedent`
+      // $ExpectType { a: number; b: "on"; }
+      const t = { a: 17, b: 'on' as const };
     `,
     optionsSet: [[]],
   },

--- a/tests/rules/expect-type.test.ts
+++ b/tests/rules/expect-type.test.ts
@@ -30,6 +30,15 @@ const valid: ReadonlyArray<ValidTestCase> = [
     `,
     optionsSet: [[]],
   },
+  // Twoslash type from #4
+  {
+    code: dedent`
+      const square = (x: number) => x * x;
+      const four = square(2);
+      //    ^? number
+    `,
+    optionsSet: [[]],
+  },
   // Ignored TypeScript compiler complaints
   {
     code: dedent`

--- a/tests/rules/expect-type.test.ts
+++ b/tests/rules/expect-type.test.ts
@@ -13,6 +13,7 @@ const valid: ReadonlyArray<ValidTestCase> = [
       //    ^? { a: number; b: "on"; }
     `,
     optionsSet: [[]],
+    only: true,
   },
   // Complex type
   {

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -46,6 +46,14 @@ const valid: ReadonlyArray<ValidTestCase> = [
     `,
     optionsSet: [[]],
   },
+  // Test for a type alias
+  {
+    code: dedent`
+      type MyType = 123;
+      //   ^? type MyType = 123
+    `,
+    optionsSet: [[]],
+  },
 ];
 
 // Invalid test cases.
@@ -109,6 +117,21 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       const four = 4;
       //    ^? const four: 4
     `,
+  },
+  // no space after "^?"
+  {
+    code: dedent`
+      type MyType = 123;
+      //   ^?type MyType = 123
+    `,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: 'SyntaxError',
+        line: 2,
+        column: 1,
+      },
+    ],
   },
   // Two twoslash assertions on a single line. Only the first one is used.
   {

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -23,6 +23,17 @@ const valid: ReadonlyArray<ValidTestCase> = [
     `,
     optionsSet: [[]],
   },
+  // Multiline twoslash
+  {
+    code: dedent`
+      const t = { a: 17, b: 'on' as const };
+      //    ^? const t: {
+      //         a: number;
+      //         b: "on";
+      //       }
+    `,
+    optionsSet: [[]],
+  },
 ];
 
 // Invalid test cases.
@@ -38,6 +49,24 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       {
         messageId: 'TypesDoNotMatch',
         line: 2,
+        column: 7,
+      },
+    ],
+  },
+  // While whitespace is ignored, field order does matter.
+  {
+    code: dedent`
+      const t = { a: 17, b: 'on' as const };
+      //    ^? const t: {
+      //         b: "on";
+      //         a: number;
+      //       }
+    `,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: 'TypesDoNotMatch',
+        line: 1,
         column: 7,
       },
     ],

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -83,7 +83,7 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
         messageId: 'TypesDoNotMatch',
         line: 1,
         column: 7,
-      }
+      },
     ],
     output: dedent`
       const four = 4;
@@ -93,7 +93,8 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
   },
   // Same as previous, but with a space already present after the ^?
   {
-    code: dedent`
+    code:
+      dedent`
       const four = 4;
       //    ^?` + ' ',
     optionsSet: [[]],
@@ -102,7 +103,7 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
         messageId: 'TypesDoNotMatch',
         line: 1,
         column: 7,
-      }
+      },
     ],
     output: dedent`
       const four = 4;
@@ -233,7 +234,7 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       {
         messageId: 'OrphanAssertion',
         line: 2,
-        column: 1,  // would column 3 be better?
+        column: 1, // would column 3 be better?
       },
     ],
   },

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -52,6 +52,11 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
         column: 7,
       },
     ],
+    output: dedent`
+      const square = (x: number) => x * x;
+      const four = square(2);
+      //    ^? const four: number
+    `,
   },
   // While whitespace is ignored, field order does matter.
   {
@@ -70,6 +75,13 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
         column: 7,
       },
     ],
+    output: dedent`
+      const t = { a: 17, b: 'on' as const };
+      //    ^? const t: {
+      //           a: number;
+      //           b: "on";
+      //       }
+    `,
   },
 ];
 

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -70,6 +70,27 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       //    ^? const four: number
     `,
   },
+  // Offers a fix for an empty assertion (the usual starting point)
+  {
+    code: dedent`
+      const four = 4;
+      //    ^?
+      // next line
+    `,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: 'TypesDoNotMatch',
+        line: 1,
+        column: 7,
+      }
+    ],
+    output: dedent`
+      const four = 4;
+      //    ^? const four: 4
+      // next line
+    `,
+  },
   // Fixer for comment that doesn't continue the twoslash comment
   {
     code: dedent`

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -97,6 +97,27 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       const square = (x: number) => x * x;
       const four = square(2);
       //    ^? const four: string
+    `,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: 'TypesDoNotMatch',
+        line: 2,
+        column: 7,
+      },
+    ],
+    output: dedent`
+      const square = (x: number) => x * x;
+      const four = square(2);
+      //    ^? const four: number
+    `,
+  },
+  // Same as above but not the last line of the file
+  {
+    code: dedent`
+      const square = (x: number) => x * x;
+      const four = square(2);
+      //    ^? const four: string
       // not the last line.
     `,
     optionsSet: [[]],

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -106,6 +106,21 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       //       }
     `,
   },
+  {
+    code: dedent`
+      const square = (x: number) => x * x;
+      const four = square(2);
+      // ^? const four: string
+    `,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: 'OrphanAssertion',
+        line: 2,
+        column: 1,  // would column 3 be better?
+      },
+    ],
+  },
 ];
 
 describe('TwoSlash', () => {

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -110,6 +110,25 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       //    ^? const four: 4
     `,
   },
+  // Two twoslash assertions on a single line. Only the first one is used.
+  {
+    code: dedent`
+      let x = 4, y = "four";
+      //  ^?     ^? let y: string
+    `,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: 'TypesDoNotMatch',
+        line: 1,
+        column: 5,
+      },
+    ],
+    output: dedent`
+      let x = 4, y = "four";
+      //  ^? let x: number
+    `,
+  },
   // Fixer for comment that doesn't continue the twoslash comment
   {
     code: dedent`

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -58,6 +58,29 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       //    ^? const four: number
     `,
   },
+  // Fixer for comment that doesn't continue the twoslash comment
+  {
+    code: dedent`
+      const square = (x: number) => x * x;
+      const four = square(2);
+      //    ^? const four: string
+      // not the last line.
+    `,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: 'TypesDoNotMatch',
+        line: 2,
+        column: 7,
+      },
+    ],
+    output: dedent`
+      const square = (x: number) => x * x;
+      const four = square(2);
+      //    ^? const four: number
+      // not the last line.
+    `,
+  },
   // While whitespace is ignored, field order does matter.
   {
     code: dedent`

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -34,6 +34,18 @@ const valid: ReadonlyArray<ValidTestCase> = [
     `,
     optionsSet: [[]],
   },
+  // Multiline twoslash with another comment after it.
+  {
+    code: dedent`
+      const t = { a: 17, b: 'on' as const };
+      //    ^? const t: {
+      //         a: number;
+      //         b: "on";
+      //       }
+      // This is an unrelated, non-twoslash comment.
+    `,
+    optionsSet: [[]],
+  },
 ];
 
 // Invalid test cases.
@@ -104,6 +116,50 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       //           a: number;
       //           b: "on";
       //       }
+    `,
+  },
+  // A single line assertion can become a multiline after fixing.
+  {
+    code: dedent`
+      const t = { a: 17, b: 'on' as const };
+      //    ^? const t: boolean
+    `,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: 'TypesDoNotMatch',
+        line: 1,
+        column: 7,
+      },
+    ],
+    output: dedent`
+      const t = { a: 17, b: 'on' as const };
+      //    ^? const t: {
+      //           a: number;
+      //           b: "on";
+      //       }
+    `,
+  },
+  // A multiline assertion can become a single line after fixing.
+  {
+    code: dedent`
+      let four = 4;
+      //    ^? let four: {
+      //           a: number;
+      //           b: "on";
+      //       }
+    `,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: 'TypesDoNotMatch',
+        line: 1,
+        column: 5,
+      },
+    ],
+    output: dedent`
+      let four = 4;
+      //    ^? let four: number
     `,
   },
   {

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -91,6 +91,24 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       // next line
     `,
   },
+  // Same as previous, but with a space already present after the ^?
+  {
+    code: dedent`
+      const four = 4;
+      //    ^?` + ' ',
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: 'TypesDoNotMatch',
+        line: 1,
+        column: 7,
+      }
+    ],
+    output: dedent`
+      const four = 4;
+      //    ^? const four: 4
+    `,
+  },
   // Fixer for comment that doesn't continue the twoslash comment
   {
     code: dedent`

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -121,6 +121,36 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       },
     ],
   },
+  {
+    code: dedent`
+      const four = 4;  // intentional blank below!
+
+      // ^? const four: number
+    `,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: 'OrphanAssertion',
+        line: 3,
+        column: 1,
+      },
+    ],
+  },
+  // Can't have an assertion on the first line of a file.
+  {
+    code: dedent`
+      // ^? const four: number
+      const four = 4;
+    `,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: 'OrphanAssertion',
+        line: 1,
+        column: 1,
+      },
+    ],
+  },
 ];
 
 describe('TwoSlash', () => {

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -253,7 +253,7 @@ const invalid: ReadonlyArray<InvalidTestCase> = [
       {
         messageId: 'OrphanAssertion',
         line: 2,
-        column: 1, // would column 3 be better?
+        column: 1,
       },
     ],
   },

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -1,0 +1,53 @@
+import dedent from 'dedent';
+import { RuleTester, Rule } from 'eslint';
+import { typescript } from '../helpers/configs';
+import { InvalidTestCase, processInvalidTestCase, processValidTestCase, ValidTestCase } from '../helpers/util';
+import { name, rule } from '../../src/rules/expect';
+
+// Valid test cases.
+const valid: ReadonlyArray<ValidTestCase> = [
+  // Twoslash
+  {
+    code: dedent`
+      const t = { a: 17, b: 'on' as const };
+      //    ^? const t: { a: number; b: "on"; }
+    `,
+    optionsSet: [[]],
+  },
+  // Twoslash type from #4
+  {
+    code: dedent`
+      const square = (x: number) => x * x;
+      const four = square(2);
+      //    ^? const four: number
+    `,
+    optionsSet: [[]],
+  },
+];
+
+// Invalid test cases.
+const invalid: ReadonlyArray<InvalidTestCase> = [
+  {
+    code: dedent`
+      const square = (x: number) => x * x;
+      const four = square(2);
+      //    ^? const four: string
+    `,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: 'TypesDoNotMatch',
+        line: 2,
+        column: 7,
+      },
+    ],
+  },
+];
+
+describe('TwoSlash', () => {
+  const ruleTester = new RuleTester(typescript);
+  ruleTester.run(name, rule as unknown as Rule.RuleModule, {
+    valid: processValidTestCase(valid),
+    invalid: processInvalidTestCase(invalid),
+  });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to eslint-plugin-expect-type! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

- [x] Addresses an existing issue: closes #43
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/labels/status%3A%20accepting%20prs)

## Overview

Adds support for the following syntax:

```ts
const square = (x: number) => x * x;
const four = square(2);
//    ^? const four: number
```

Multiline types look like:

```ts
const vector = {
  x: 3,
  y: 4,
};
vector
// ^? const vector: {
//        x: number;
//        y: number;
//    }
```

A comment line is a continuation of the expected type if it starts with the exact same sequence of spaces and `//` as the `^?` line (with `^?` replaced with more spaces).

This also includes a fixer. I've only enabled it for twoslash-style assertions, but enabling it for `$ExpectType` would be trivial. This might really improve the dev experience for DefinitelyTyped contributors!

Here are some GIFs of it in action.

Single line fix:
![expect-type-fix](https://user-images.githubusercontent.com/98301/162592605-184fe6e5-e069-4a63-aa87-387f4e1b85df.gif)

More complex fix that involves multiple files / a multiline type:
![expect-type-multiline-fix](https://user-images.githubusercontent.com/98301/162632519-c9cd2744-a3dd-45f9-8b6b-d91e1cab4ad9.gif)



