### PR TITLE
Version bump 0.1.0 → 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-expect-type",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "ESLint plugin with $ExpectType, $ExpectError and $ExpectTypeSnapshot type assertions",
   "author": {
     "name": "Josh Goldberg"


### PR DESCRIPTION
This version is already published on npm. I would've just pushed this directly to `main`, but I got this error:

```
Enumerating objects: 5, done.
Counting objects: 100% (5/5), done.
Delta compression using up to 8 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 290 bytes | 290.00 KiB/s, done.
Total 3 (delta 2), reused 0 (delta 0)
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: error: 4 of 4 required status checks are expected. At least 1 approving review is required by reviewers with write access.
To https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type.git
 ! [remote rejected] main -> main (protected branch hook declined)
error: failed to push some refs to 'https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type.git'
```