### PR TITLE
docs: add missing TypeScript syntax highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ eslint --fix
 
 This plugin also supports twoslash annotations, which is a comment line that starts with two slashes (`// `) and the `^?` identifier to annotate the symbol you're interested in:
 
-```
+```ts
 const square = (x: number) => x * x;
 const four = square(2);
 //    ^? const four: number
@@ -115,7 +115,7 @@ const four = square(2);
 
 Multiline type annotations are also supported:
 
-```
+```ts
 const vector = {
   x: 3,
   y: 4,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to eslint-plugin-expect-type! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

- [ ] Addresses an existing issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->
Add syntax highlight to twoslash examples in docs