### PR TITLE
Update getLanguageServiceHost() to support TS 4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ const vector = {
   x: 3,
   y: 4,
 };
-vector
+vector;
 // ^? const vector: {
 //        x: number;
 //        y: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-expect-type",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-expect-type",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript-eslint/utils": "^5.0.0",
@@ -35,7 +35,7 @@
         "prettier": "^2.6.0",
         "ts-jest": "^27.1.3",
         "tsutils": "^3.21.0",
-        "typescript": "^4.6.2"
+        "typescript": "^4.8.2"
       },
       "engines": {
         "node": ">=14"
@@ -5724,9 +5724,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10257,9 +10257,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg=="
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     "prettier": "^2.6.0",
     "ts-jest": "^27.1.3",
     "tsutils": "^3.21.0",
-    "typescript": "^4.6.2"
+    "typescript": "^4.8.2"
   }
 }

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -511,6 +511,8 @@ function getLanguageServiceHost(program: ts.Program): ts.LanguageServiceHost {
     getScriptFileNames: () => program.getSourceFiles().map((sourceFile) => sourceFile.fileName),
     getScriptSnapshot: (name) => ts.ScriptSnapshot.fromString(program.getSourceFile(name)?.text ?? ''),
     getScriptVersion: () => '1',
+    fileExists: (path) => !!program.getSourceFile(path),
+    readFile: (path) => program.getSourceFile(path)?.text ?? '',
   };
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing issue: fixes #60 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/labels/status%3A%20accepting%20prs)

## Overview

As of https://github.com/microsoft/TypeScript/pull/47495 there are two new required properties on `LanguageServiceHost`. This fills them out.