### PR TITLE
fix: factor all whitespace in first-on-line check

### DIFF
--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -433,7 +433,7 @@ function parseTwoslashAssertion(
 
 function isFirstOnLine(text: string, lineStart: number, pos: number): boolean {
   for (let i = lineStart; i < pos; i++) {
-    if (text[i] !== ' ') {
+    if (/\S/.test(text[i])) {
       return false;
     }
   }

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -67,6 +67,14 @@ runRuleTests({
       filename,
       options: [],
     },
+    // Tab indentation: #64
+    {
+      code: `
+	const bar = {"test": 123}
+	//    ^? const bar: { test: number; }
+      `,
+      filename,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing issue: fixes #64
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/labels/status%3A%20accepting%20prs)

## Overview

This was a fun investigation! Turns out `isFirstOnLine`, a function used to determine whether a position starts a line, was only counting `' '` (spaces) - not `'\t'` tabs.