### PR TITLE
Fix example and link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Then, you'll be able to use `^?`, `$ExpectError`, `$ExpectType`, and `$ExpectTyp
 You might consider using other popular type assertion libraries in the TypeScript ecosystem:
 
 - **[expect-type](https://github.com/mmkal/expect-type)**: Provides functions that return assorted generic type assertion methods, such as `expectTypeOf('abc').toMatchTypeOf<string>()`.
-- **[ts-expect](https://github.com/mmkal/expect-type)**: Provides generic type assertion function, used like `expectType<string>('abc')()`.
+- **[ts-expect](https://github.com/TypeStrong/ts-expect)**: Provides generic type assertion function, used like `expectType<string>('abc')()`.
 - **[tsd](https://github.com/SamVerschueren/tsd)**: Allows writing tests specifically for `.d.ts` definition files.
 
 ## Appreciation

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 > ESLint plugin with `^?` Twoslash, `$ExpectError`, and `$ExpectType` type assertions. ✨
 
 ```ts
-9001;
-// ^? number
+let val = 9001;
+//  ^? let val: number
 
 // $ExpectError
 const value: string = 9001;

--- a/tests/rules/twoslash.test.ts
+++ b/tests/rules/twoslash.test.ts
@@ -13,6 +13,14 @@ runRuleTests({
       filename,
       options: [],
     },
+    {
+      code: dedent`
+      let val = 9001;
+      //  ^? let val: number
+      `,
+      filename,
+      options: [],
+    },
     // Twoslash type from #4
     {
       code: dedent`


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to eslint-plugin-expect-type! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

- [ ] Addresses an existing issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/labels/status%3A%20accepting%20prs)

(neither or these)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

The first twoslash example in `README.md` looked a little funny to me so I put it in a unit test and sure enough, you get an error:

```
    Message:
      Should have no errors but had 1: [
      {
        ruleId: 'expect',
        severity: 1,
        message: 'Can not match a node to this assertion.',
        line: 1,
        column: 1,
        nodeType: null,
        messageId: 'OrphanAssertion'
      }
    ]
```

clearly we need to run literate-ts on this! :)

I fixed code sample, added a corresponding unit test and also fixed a mismatched link I noticed.