### PR TITLE
docs: add explanation of display checking

### DIFF
--- a/docs/rules/expect.md
+++ b/docs/rules/expect.md
@@ -10,9 +10,8 @@
 
 Enforces that types indicated in special comments match the types of code values.
 
-> [!NOTE]
 > Types are compared with _"display"_ checking: meaning a direct string comparison between their actual type and the string comment or snapshot.
-> [Issue #18](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/issues/18) tracks adding a new assertion for _"assignability"_ checking.
+> See [issue #18](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/issues/18) for discussion around a new assertion for _"assignability"_ checking.
 
 ## Comment Types
 

--- a/docs/rules/expect.md
+++ b/docs/rules/expect.md
@@ -10,7 +10,7 @@
 
 Enforces that types indicated in special comments match the types of code values.
 
-> Types are compared with _"display"_ checking: meaning a direct string comparison between their actual type and the string comment or snapshot.
+> Types are compared with _"display"_ checking: a direct string comparison between their actual type and the string comment or snapshot.
 > See [issue #18](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/issues/18) for discussion around a new assertion for _"assignability"_ checking.
 
 ## Comment Types

--- a/docs/rules/expect.md
+++ b/docs/rules/expect.md
@@ -10,6 +10,10 @@
 
 Enforces that types indicated in special comments match the types of code values.
 
+> [!NOTE]
+> Types are compared with _"display"_ checking: meaning a direct string comparison between their actual type and the string comment or snapshot.
+> [Issue #18](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/issues/18) tracks adding a new assertion for _"assignability"_ checking.
+
 ## Comment Types
 
 The following kinds of comments are supported:


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-expect-type! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #50
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a brief note in the `expect` rule docs.

I don't think we need more than that given the README.md links to neighboring packages.