### PR TITLE
feat: clarify TypeScript support range

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ You might consider using other popular type assertion libraries in the TypeScrip
 - **[tsd](https://github.com/SamVerschueren/tsd)**: Allows writing tests specifically for `.d.ts` definition files.
 - **[Vitest](https://vitest.dev/guide/testing-types.html)**: Includes `assertType` and `expectTypeOf` assertions.
 
+## TypeScript Version Support
+
+`eslint-plugin-expect-type` mirrors the [DefinitelyTyped TypeScript Support Window](https://github.com/DefinitelyTyped/DefinitelyTyped/#support-window).
+Roughly, that's major versions of TypeScript less than 2 years old.
+
 ## Appreciation
 
 Many thanks to [@ibezkrovnyi](https://github.com/ibezkrovnyi) for creating the initial version and core infrastructure of this package! 💖

--- a/src/rules/expect.ts
+++ b/src/rules/expect.ts
@@ -583,10 +583,9 @@ function getExpectTypeFailures(
 	languageService: ts.LanguageService,
 ): ExpectTypeFailures {
 	const { twoSlashAssertions, typeAssertions } = assertions;
-
 	const unmetExpectations: UnmetExpectation[] = [];
+
 	// Match assertions to the first node that appears on the line they apply to.
-	// `forEachChild` isn't available as a method in older TypeScript versions, so must use `ts.forEachChild` instead.
 	ts.forEachChild(sourceFile, function iterate(node) {
 		const line = lineOfPosition(node.getStart(sourceFile), sourceFile);
 		const assertion = typeAssertions.get(line);
@@ -692,11 +691,10 @@ function matchModuloWhitespace(actual: string, expected: string): boolean {
 }
 
 function getNodeForExpectType(node: ts.Node): ts.Node {
-	if (node.kind === ts.SyntaxKind.VariableStatement) {
-		// ts2.0 doesn't have `isVariableStatement`
+	if (ts.isVariableStatement(node)) {
 		const {
 			declarationList: { declarations },
-		} = node as ts.VariableStatement;
+		} = node;
 		if (declarations.length === 1) {
 			const { initializer } = declarations[0];
 			if (initializer) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #68
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Aligns to the DefinitelyTyped support range and removes a workaround for TS2.0.