### PR TITLE
fix: make `recommended` config a valid flat config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
-import { recommendedRuleSettings } from "./plugin.js";
+import { plugin, recommendedRuleSettings } from "./plugin.js";
 
 export { rules } from "./rules/index.js";
 
 export const configs = {
 	recommended: {
-		plugins: ["expect-type"],
+		plugins: {
+			"expect-type": plugin,
+		},
 		rules: recommendedRuleSettings,
 	},
 };

--- a/src/rules/twoslash.test.ts
+++ b/src/rules/twoslash.test.ts
@@ -5,26 +5,6 @@ import { filename, ruleTester } from "./ruleTester.js";
 
 ruleTester.run("expect", expect, {
 	invalid: [
-		{
-			code: dedent`
-        const square = (x: number) => x * x;
-        const four = square(2);
-        //    ^? const four: string
-      `,
-			errors: [
-				{
-					column: 7,
-					line: 2,
-					messageId: "TypesDoNotMatch",
-				},
-			],
-			filename,
-			output: dedent`
-        const square = (x: number) => x * x;
-        const four = square(2);
-        //    ^? const four: number
-      `,
-		},
 		// Offers a fix for an empty assertion (the usual starting point)
 		{
 			code: dedent`

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,6 +1,3 @@
-export type SetRequiredNonNullable<
-	BaseType,
-	Keys extends keyof BaseType,
-> = Omit<BaseType, Keys> & {
+export type SetRequiredNonNullable<BaseType, Keys extends keyof BaseType> = {
 	[K in Keys]: NonNullable<BaseType[K]>;
-};
+} & Omit<BaseType, Keys>;


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-expect-type! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [X] Addresses an existing open issue: fixes #142
- [X] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [X] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR updates the `recommended` config to make it a valid flat config. Currently, the `recommended` config's `plugins` field is an array, and thus this config cannot be used in flat mode, where `plugins` is expected to be an object.

It looks like the readme file already contains instructions for embedding the `recommended` config in a flat config file, but the `recommended` config itself hasn't been updated yet.

```js
import expectType from "eslint-plugin-expect-type/configs/recommended";

export default [
	// your other ESLint configurations
	expectType,
];
```

I noticed this problem while working on eslint/eslint#18869.