### PR TITLE
fix: revert src/index.ts back to legacy config format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,10 @@
-import { plugin, recommendedRuleSettings } from "./plugin.js";
+import { recommendedRuleSettings } from "./plugin.js";
 
 export { rules } from "./rules/index.js";
 
 export const configs = {
 	recommended: {
-		plugins: {
-			"expect-type": plugin,
-		},
+		plugins: ["expect-type"],
 		rules: recommendedRuleSettings,
 	},
 };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #486
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Reverts the part of #462 that changed `src/index.ts`. That file is still the legacy config format; it's `eslint-plugin-expect-type/configs/recommended`. Repro: https://github.com/JoshuaKGoldberg/repros/tree/eslint-plugin-expect-type-eslint-configs

💖 