### PR TITLE
docs: add TSTyche to the References section

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,16 @@ If you're still using the [legacy ESLint configuration file format](https://esli
 
 ## References
 
-You might consider using other popular type assertion libraries in the TypeScript ecosystem:
+You might consider using other popular type assertion libraries:
 
 - **[expect-type](https://github.com/mmkal/expect-type)**: Provides functions that return assorted generic type assertion methods, such as `expectTypeOf('abc').toMatchTypeOf<string>()`.
 - **[ts-expect](https://github.com/TypeStrong/ts-expect)**: Provides generic type assertion function, used like `expectType<string>('abc')()`.
-- **[tsd](https://github.com/SamVerschueren/tsd)**: Allows writing tests specifically for `.d.ts` definition files.
 - **[Vitest](https://vitest.dev/guide/testing-types.html)**: Includes `assertType` and `expectTypeOf` assertions.
+
+Or tools:
+
+- **[tsd](https://github.com/SamVerschueren/tsd)**: Allows writing tests specifically for `.d.ts` definition files.
+- **[TSTyche](https://tstyche.org)**: A type testing tool that ships with `describe()` and `test()` helpers, `expect` style assertions and a mighty test runner which allows to use specified version of TypeScript.
 
 ## TypeScript Version Support
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If you're still using the [legacy ESLint configuration file format](https://esli
 
 ## References
 
-You might consider using other popular type assertion libraries:
+You might consider using other popular libraries and tools that can run type assertions:
 
 - **[expect-type](https://github.com/mmkal/expect-type)**: Provides functions that return assorted generic type assertion methods, such as `expectTypeOf('abc').toMatchTypeOf<string>()`.
 - **[ts-expect](https://github.com/TypeStrong/ts-expect)**: Provides generic type assertion function, used like `expectType<string>('abc')()`.


### PR DESCRIPTION
## Overview

I would lie to propose adding TSTyche (a project of mine) to the References list.

---

TSTyche is relatively new type testing tool. It felt like this project is trying to mention all actively maintained alternative libraries. So here is one more (;

I have created a separate section, because TSTyche is not just a “type assertion library”. It is a type test runner. In my opinion, only tsd is providing similar feature. But is far far far ... behind. For instance, tsd was designed to test hand crafted `.d.ts` declarations, but unit type testing or mono repo support is not implemented and not event planned. Oh well.. (;

---

Feel free to adjust the text. I just wanted to updated the References list (;