### PR TITLE
fix: remove unusable message IDs

### DIFF
--- a/src/assertions/types.ts
+++ b/src/assertions/types.ts
@@ -2,11 +2,6 @@ export type Assertion = ManualAssertion | SnapshotAssertion | TwoSlashAssertion;
 
 export interface Assertions {
 	/**
-	 * Lines with more than one assertion (these are errors).
-	 */
-	readonly duplicates: readonly number[];
-
-	/**
 	 * Lines with an $ExpectError.
 	 */
 	readonly errorLines: ReadonlySet<number>;

--- a/src/rules/expect-type.test.ts
+++ b/src/rules/expect-type.test.ts
@@ -7,9 +7,41 @@ ruleTester.run("expect", expect, {
 	invalid: [
 		{
 			code: dedent`
+      // $ExpectType
+      'a';
+      `,
+			errors: [
+				{
+					column: 1,
+					data: {
+						message:
+							'$ExpectType requires type argument (e.g. // $ExpectType "string")',
+					},
+					line: 2,
+					messageId: "SyntaxError",
+				},
+			],
+			filename,
+		},
+		{
+			code: dedent`
+      // $ExpectType number
+      'a';
+      `,
+			errors: [
+				{
+					column: 1,
+					line: 2,
+					messageId: "TypesDoNotMatch",
+				},
+			],
+			filename,
+		},
+		{
+			code: dedent`
       // $ExpectType number
       const t = 'a';
-np    `,
+      `,
 			errors: [
 				{
 					column: 1,

--- a/src/rules/sandbox/__type-snapshots__/file.ts.snap.json
+++ b/src/rules/sandbox/__type-snapshots__/file.ts.snap.json
@@ -2,5 +2,7 @@
 	"SnapshotMatches": "{ a: number; b: \"b\"; c: string; }",
 	"SnapshotMatchesOr": "{ a: number; b: \"b\"; c: string; } || { d: boolean }",
 	"TypeSnapshotDoNotMatch": "{ a: number; b: \"b\"; c: boolean; }",
-	"TypeSnapshotDoNotMatchOr": "{ a: number; b: \"b\"; c: boolean; } { d: boolean }"
+	"TypeSnapshotDoNotMatchOr": "{ a: number; b: \"b\"; c: boolean; } { d: boolean }",
+	"SnapshotNotFoundFixing": "boolean[]",
+	"SnapshotNotMatchedFixing": "boolean[]"
 }

--- a/src/utils/snapshot.ts
+++ b/src/utils/snapshot.ts
@@ -19,14 +19,14 @@ export const getTypeSnapshot = (filename: string, snapshotName: string) => {
 export const updateTypeSnapshot = (
 	filename: string,
 	snapshotName: string,
-	actualType: string,
+	actualType: null | string,
 ) => {
 	const snapshotPath = getSnapshotPath(filename);
 	ensureFileSync(snapshotPath);
 
 	const json =
 		(readJsonSync(snapshotPath, { throws: false }) as
-			| Record<string, string>
+			| Record<string, null | string>
 			| undefined) ?? {};
 	json[snapshotName] = actualType;
 	writeJsonSync(snapshotPath, json, { spaces: 2 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #114; fixes #636; fixes #638
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes the unreachable `FileIsNotIncludedInTSConfig` and `Multiple$ExpectTypeAssertions` message IDs.

Also fills in some tests around snapshots (#114) to feel more safe in doing so.

💖 