### PR TITLE
fix: clear programs cache if >90% of heap is used

### DIFF
--- a/src/utils/programs.test.ts
+++ b/src/utils/programs.test.ts
@@ -1,0 +1,47 @@
+import ts from "typescript";
+import { describe, expect, it, vi } from "vitest";
+
+import { getProgramForVersion } from "./programs.js";
+
+const mockGetHeapStatistics = vi.fn<() => Record<string, number>>();
+
+vi.mock("node:v8", () => ({
+	get default() {
+		return { getHeapStatistics: mockGetHeapStatistics };
+	},
+}));
+
+const originalProgram = ts.createProgram({
+	options: {},
+	rootNames: [],
+});
+
+function actGetProgramForVersion() {
+	return getProgramForVersion("tsconfig.json", ts, "current", originalProgram);
+}
+
+describe("getProgramForVersion", () => {
+	it("reuses old programs when <90% of the heap is used", () => {
+		mockGetHeapStatistics.mockReturnValue({
+			heap_size_limit: 100,
+			used_heap_size: 90,
+		});
+
+		const programA = actGetProgramForVersion();
+		const programB = actGetProgramForVersion();
+
+		expect(programA).toBe(programB);
+	});
+
+	it("does not reuse old programs when >90% of the heap is used", () => {
+		mockGetHeapStatistics.mockReturnValue({
+			heap_size_limit: 100,
+			used_heap_size: 91,
+		});
+
+		const programA = actGetProgramForVersion();
+		const programB = actGetProgramForVersion();
+
+		expect(programA).not.toBe(programB);
+	});
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #642
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I played around with different strategies a bit, but ended up doing basically the same thing as https://github.com/microsoft/DefinitelyTyped-tools/pull/1024. Therefore:

Co-authored-by: Andrew Branch <andrew@wheream.io>