### PR TITLE
fix: allow spaces around assertions

### DIFF
--- a/src/assertions/parseAssertions.ts
+++ b/src/assertions/parseAssertions.ts
@@ -26,14 +26,14 @@ export function parseAssertions(sourceFile: ts.SourceFile): Assertions {
 		// i.e. `// foo; // $ExpectType number`
 		const comment = commentMatch[1];
 		// eslint-disable-next-line regexp/no-unused-capturing-group
-		const matchExpect = /^ ?\$Expect(TypeSnapshot|Type|Error)( (.*))?$/.exec(
+		const matchExpect = /^\s*\$Expect(TypeSnapshot|Type|Error)( (.*))?$/.exec(
 			comment,
 		) as [never, "Error" | "Type" | "TypeSnapshot", never, string?] | null;
 		const commentIndex = commentMatch.index;
 		const line = getLine(commentIndex);
 		if (matchExpect) {
 			const directive = matchExpect[1];
-			const payload = matchExpect[3];
+			const payload = matchExpect[3]?.trim();
 			switch (directive) {
 				case "Error":
 					errorLines.add(line);

--- a/src/rules/expect-type.test.ts
+++ b/src/rules/expect-type.test.ts
@@ -39,6 +39,21 @@ ruleTester.run("expect", expect, {
 		},
 		{
 			code: dedent`
+      //   $ExpectType   number${"  "}
+      'a';
+      `,
+			errors: [
+				{
+					column: 1,
+					data: { actual: '"a"', expected: "number" },
+					line: 2,
+					messageId: "TypesDoNotMatch",
+				},
+			],
+			filename,
+		},
+		{
+			code: dedent`
       // $ExpectType number
       const t = 'a';
       `,
@@ -103,6 +118,14 @@ ruleTester.run("expect", expect, {
     `,
 			filename,
 			name: "Primitive type",
+		},
+		{
+			code: dedent`
+      // ... // $ExpectType string
+      const t = 6 as number;
+    `,
+			filename,
+			name: "Commented type",
 		},
 		{
 			code: dedent`


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #644
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Updates the regular expression to allow any amount of spaces between the `//` and the rest of the type. Also updates the payload to `.trim()`.

Similar in implementation to https://github.com/microsoft/DefinitelyTyped-tools/pull/1011, so:

Co-authored-by: @jakebailey